### PR TITLE
Separate logger and encoder configuration

### DIFF
--- a/blip_test.go
+++ b/blip_test.go
@@ -95,6 +95,7 @@ func BenchmarkBare(b *testing.B) {
 		Level:           blip.LevelDebug,
 		Output:          io.Discard,
 		StackTraceLevel: blip.LevelError,
+		Encoder:         &blip.ConsoleEncoder{},
 	})
 	ctx := context.Background()
 
@@ -111,12 +112,11 @@ func BenchmarkBare(b *testing.B) {
 
 func BenchmarkOptimized(b *testing.B) {
 	log.Setup(blip.Config{
-		Level:         blip.LevelDebug,
-		Output:        io.Discard,
-		Time:          true,
-		TimeFormat:    "2006-01-02 15:04:05.000",
-		TimePrecision: 1 * time.Millisecond,
-		Encoder: blip.ConsoleEncoder{
+		Level:  blip.LevelDebug,
+		Output: io.Discard,
+		Encoder: &blip.ConsoleEncoder{
+			TimeFormat:      "2006-01-02 15:04:05.000",
+			TimePrecision:   1 * time.Millisecond,
 			Color:           false,
 			MinMessageWidth: 0,
 			SortFields:      false,
@@ -138,12 +138,11 @@ func BenchmarkOptimized(b *testing.B) {
 
 func BenchmarkPretty(b *testing.B) {
 	log.Setup(blip.Config{
-		Level:         blip.LevelDebug,
-		Output:        io.Discard,
-		Time:          true,
-		TimeFormat:    "2006-01-02 15:04:05.000",
-		TimePrecision: 1 * time.Millisecond,
-		Encoder: blip.ConsoleEncoder{
+		Level:  blip.LevelDebug,
+		Output: io.Discard,
+		Encoder: &blip.ConsoleEncoder{
+			TimeFormat:      "2006-01-02 15:04:05.000",
+			TimePrecision:   1 * time.Millisecond,
 			Color:           true,
 			MinMessageWidth: 40,
 			SortFields:      false,
@@ -165,12 +164,11 @@ func BenchmarkPretty(b *testing.B) {
 
 func BenchmarkPrettySorted(b *testing.B) {
 	log.Setup(blip.Config{
-		Level:         blip.LevelDebug,
-		Output:        io.Discard,
-		Time:          true,
-		TimeFormat:    "2006-01-02 15:04:05.000",
-		TimePrecision: 1 * time.Millisecond,
-		Encoder: blip.ConsoleEncoder{
+		Level:  blip.LevelDebug,
+		Output: io.Discard,
+		Encoder: &blip.ConsoleEncoder{
+			TimeFormat:      "2006-01-02 15:04:05.000",
+			TimePrecision:   1 * time.Millisecond,
 			Color:           true,
 			MinMessageWidth: 40,
 			SortFields:      true,
@@ -192,12 +190,11 @@ func BenchmarkPrettySorted(b *testing.B) {
 
 func BenchmarkPrettySortedContext(b *testing.B) {
 	log.Setup(blip.Config{
-		Level:         blip.LevelDebug,
-		Output:        io.Discard,
-		Time:          true,
-		TimeFormat:    "2006-01-02 15:04:05.000",
-		TimePrecision: 1 * time.Millisecond,
-		Encoder: blip.ConsoleEncoder{
+		Level:  blip.LevelDebug,
+		Output: io.Discard,
+		Encoder: &blip.ConsoleEncoder{
+			TimeFormat:      "2006-01-02 15:04:05.000",
+			TimePrecision:   1 * time.Millisecond,
 			Color:           true,
 			MinMessageWidth: 40,
 			SortFields:      true,

--- a/blip_test.go
+++ b/blip_test.go
@@ -19,7 +19,7 @@ import (
 
 func FuzzBlip(f *testing.F) {
 	cfg := blip.DefaultConfig()
-	cfg.Encoder = blip.NewJSONEncoder(cfg)
+	cfg.Encoder = blip.NewJSONEncoder()
 	ctx := context.Background()
 
 	// Seed inputs
@@ -75,7 +75,7 @@ func BenchmarkJSON(b *testing.B) {
 		Level:           blip.LevelDebug,
 		Output:          io.Discard,
 		StackTraceLevel: blip.LevelError,
-		Encoder:         blip.NewJSONEncoder(blip.DefaultConfig()),
+		Encoder:         blip.NewJSONEncoder(),
 	})
 	ctx := context.Background()
 
@@ -111,14 +111,16 @@ func BenchmarkBare(b *testing.B) {
 
 func BenchmarkOptimized(b *testing.B) {
 	log.Setup(blip.Config{
-		Level:           blip.LevelDebug,
-		Output:          io.Discard,
-		Time:            true,
-		TimeFormat:      "2006-01-02 15:04:05.000",
-		TimePrecision:   1 * time.Millisecond,
-		Color:           false,
-		MinMessageWidth: 0,
-		SortFields:      false,
+		Level:         blip.LevelDebug,
+		Output:        io.Discard,
+		Time:          true,
+		TimeFormat:    "2006-01-02 15:04:05.000",
+		TimePrecision: 1 * time.Millisecond,
+		Encoder: blip.ConsoleEncoder{
+			Color:           false,
+			MinMessageWidth: 0,
+			SortFields:      false,
+		},
 		StackTraceLevel: blip.LevelError,
 	})
 	ctx := context.Background()
@@ -136,14 +138,16 @@ func BenchmarkOptimized(b *testing.B) {
 
 func BenchmarkPretty(b *testing.B) {
 	log.Setup(blip.Config{
-		Level:           blip.LevelDebug,
-		Output:          io.Discard,
-		Time:            true,
-		TimeFormat:      "2006-01-02 15:04:05.000",
-		TimePrecision:   1 * time.Millisecond,
-		Color:           true,
-		MinMessageWidth: 40,
-		SortFields:      false,
+		Level:         blip.LevelDebug,
+		Output:        io.Discard,
+		Time:          true,
+		TimeFormat:    "2006-01-02 15:04:05.000",
+		TimePrecision: 1 * time.Millisecond,
+		Encoder: blip.ConsoleEncoder{
+			Color:           true,
+			MinMessageWidth: 40,
+			SortFields:      false,
+		},
 		StackTraceLevel: blip.LevelError,
 	})
 	ctx := context.Background()
@@ -161,14 +165,16 @@ func BenchmarkPretty(b *testing.B) {
 
 func BenchmarkPrettySorted(b *testing.B) {
 	log.Setup(blip.Config{
-		Level:           blip.LevelDebug,
-		Output:          io.Discard,
-		Time:            true,
-		TimeFormat:      "2006-01-02 15:04:05.000",
-		TimePrecision:   1 * time.Millisecond,
-		Color:           true,
-		MinMessageWidth: 40,
-		SortFields:      true,
+		Level:         blip.LevelDebug,
+		Output:        io.Discard,
+		Time:          true,
+		TimeFormat:    "2006-01-02 15:04:05.000",
+		TimePrecision: 1 * time.Millisecond,
+		Encoder: blip.ConsoleEncoder{
+			Color:           true,
+			MinMessageWidth: 40,
+			SortFields:      true,
+		},
 		StackTraceLevel: blip.LevelError,
 	})
 	ctx := context.Background()
@@ -186,14 +192,16 @@ func BenchmarkPrettySorted(b *testing.B) {
 
 func BenchmarkPrettySortedContext(b *testing.B) {
 	log.Setup(blip.Config{
-		Level:           blip.LevelDebug,
-		Output:          io.Discard,
-		Time:            true,
-		TimeFormat:      "2006-01-02 15:04:05.000",
-		TimePrecision:   1 * time.Millisecond,
-		Color:           true,
-		MinMessageWidth: 40,
-		SortFields:      true,
+		Level:         blip.LevelDebug,
+		Output:        io.Discard,
+		Time:          true,
+		TimeFormat:    "2006-01-02 15:04:05.000",
+		TimePrecision: 1 * time.Millisecond,
+		Encoder: blip.ConsoleEncoder{
+			Color:           true,
+			MinMessageWidth: 40,
+			SortFields:      true,
+		},
 		StackTraceLevel: blip.LevelError,
 	})
 	ctx := context.Background()

--- a/buffer.go
+++ b/buffer.go
@@ -2,7 +2,6 @@ package blip
 
 import (
 	"encoding/base64"
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -21,52 +20,6 @@ const bufferSize = 1024
 //
 // Encoding
 //
-
-// WriteAny writes a value of any type to the buffer. It handles various types
-// and falls back to fmt.Sprint for unsupported types.
-//
-//nolint:gocyclo
-func (buf *Buffer) WriteAny(val any) {
-	switch v := val.(type) {
-	case string:
-		buf.WriteString(v)
-	case []byte:
-		buf.WriteBytes(v...)
-	case int:
-		buf.WriteInt(int64(v))
-	case int8:
-		buf.WriteInt(int64(v))
-	case int16:
-		buf.WriteInt(int64(v))
-	case int32:
-		buf.WriteInt(int64(v))
-	case int64:
-		buf.WriteInt(v)
-	case uint:
-		buf.WriteUint(uint64(v))
-	case uint8:
-		buf.WriteUint(uint64(v))
-	case uint16:
-		buf.WriteUint(uint64(v))
-	case uint32:
-		buf.WriteUint(uint64(v))
-	case uint64:
-		buf.WriteUint(v)
-	case float32:
-		buf.WriteFloat(float64(v), 32)
-	case float64:
-		buf.WriteFloat(v, 64)
-	case bool:
-		buf.WriteBool(v)
-	case time.Duration:
-		buf.WriteDuration(v.Truncate(DurationFieldPrecision))
-	case time.Time:
-		buf.WriteTime(v, TimeFieldFormat)
-	default:
-		// TODO: Add support for custom encoders
-		buf.WriteString(fmt.Sprint(v))
-	}
-}
 
 // Write implements the io.Writer interface.
 func (buf *Buffer) Write(b []byte) (int, error) {

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -15,16 +15,20 @@ func main() {
 	cfg := blip.DefaultConfig()
 	cfg.Level = blip.LevelDebug
 	flag.BoolVar(&cfg.Time, "time", cfg.Time, "Log timestamps")
-	flag.BoolVar(&cfg.Color, "color", cfg.Color, "Colorized output")
-	flag.BoolVar(&cfg.SortFields, "sort", cfg.SortFields, "Sort fields")
-	flag.IntVar(&cfg.MinMessageWidth, "width", cfg.MinMessageWidth, "Min message width")
+	color := flag.Bool("color", true, "Colorized output")
+	sort := flag.Bool("sort", true, "Sort fields")
+	width := flag.Int("width", 40, "Min message width")
 	encoder := flag.String("enc", "console", "Log encoder (json, console)")
 	flag.Parse()
 	switch *encoder {
 	case "json":
-		cfg.Encoder = blip.NewJSONEncoder(cfg)
+		cfg.Encoder = blip.NewJSONEncoder()
 	case "console":
-		cfg.Encoder = blip.NewConsoleEncoder(cfg)
+		cfg.Encoder = blip.ConsoleEncoder{
+			Color:           *color,
+			SortFields:      *sort,
+			MinMessageWidth: *width,
+		}
 	default:
 		panic("invalid encoder")
 	}

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	cfg := blip.DefaultConfig()
 	cfg.Level = blip.LevelDebug
-	flag.BoolVar(&cfg.Time, "time", cfg.Time, "Log timestamps")
+	timeFormat := flag.String("time", "2006-01-02 15:04:05.000", "Time format")
 	color := flag.Bool("color", true, "Colorized output")
 	sort := flag.Bool("sort", true, "Sort fields")
 	width := flag.Int("width", 40, "Min message width")
@@ -22,9 +22,12 @@ func main() {
 	flag.Parse()
 	switch *encoder {
 	case "json":
-		cfg.Encoder = blip.NewJSONEncoder()
+		enc := blip.NewJSONEncoder()
+		enc.TimeFormat = *timeFormat
+		cfg.Encoder = enc
 	case "console":
-		cfg.Encoder = blip.ConsoleEncoder{
+		cfg.Encoder = &blip.ConsoleEncoder{
+			TimeFormat:      *timeFormat,
 			Color:           *color,
 			SortFields:      *sort,
 			MinMessageWidth: *width,

--- a/cmd/pprof/main.go
+++ b/cmd/pprof/main.go
@@ -30,7 +30,7 @@ func main() {
 		Level:           blip.LevelDebug,
 		Output:          io.Discard,
 		StackTraceLevel: blip.LevelError,
-		Encoder:         blip.NewJSONEncoder(blip.DefaultConfig()),
+		Encoder:         blip.NewJSONEncoder(),
 	})
 	ctx := context.Background()
 

--- a/encoder.go
+++ b/encoder.go
@@ -1,13 +1,9 @@
 package blip
 
-import (
-	"time"
-)
-
 // Encoder is an interface for encoding log messages.
 type Encoder interface {
 	// EncodeTime encodes the time of the log message.
-	EncodeTime(buf *Buffer, t time.Time)
+	EncodeTime(buf *Buffer)
 	// EncodeLevel encodes the log level of the message.
 	EncodeLevel(buf *Buffer, lev Level)
 	// EncodeMessage encodes the log message.

--- a/encoder.go
+++ b/encoder.go
@@ -1,9 +1,13 @@
 package blip
 
+import (
+	"time"
+)
+
 // Encoder is an interface for encoding log messages.
 type Encoder interface {
 	// EncodeTime encodes the time of the log message.
-	EncodeTime(buf *Buffer, ts string)
+	EncodeTime(buf *Buffer, t time.Time)
 	// EncodeLevel encodes the log level of the message.
 	EncodeLevel(buf *Buffer, lev Level)
 	// EncodeMessage encodes the log message.
@@ -12,7 +16,4 @@ type Encoder interface {
 	EncodeFields(buf *Buffer, lev Level, fields *[]Field)
 	// EncodeStackTrace encodes the stack trace of the log message.
 	EncodeStackTrace(buf *Buffer, skip int)
-
-	// TimeFormat returns the time format used by the encoder.
-	TimeFormat() string
 }

--- a/encoder.go
+++ b/encoder.go
@@ -12,4 +12,7 @@ type Encoder interface {
 	EncodeFields(buf *Buffer, lev Level, fields *[]Field)
 	// EncodeStackTrace encodes the stack trace of the log message.
 	EncodeStackTrace(buf *Buffer, skip int)
+
+	// TimeFormat returns the time format used by the encoder.
+	TimeFormat() string
 }

--- a/encoder_console.go
+++ b/encoder_console.go
@@ -48,17 +48,17 @@ func NewConsoleEncoder() *ConsoleEncoder {
 }
 
 // EncodeTime encodes the time of the log message.
-func (e *ConsoleEncoder) EncodeTime(buf *Buffer, t time.Time) {
+func (e *ConsoleEncoder) EncodeTime(buf *Buffer) {
 	if e.TimeFormat == "" {
 		return
 	}
-	if e.TimePrecision > 0 && e.timeCache == nil {
+	if e.timeCache == nil && e.TimePrecision > 0 {
 		e.timeCache = timeCache(e.TimeFormat, e.TimePrecision)
 	}
-	if e.timeCache == nil {
-		buf.WriteTime(t, e.TimeFormat)
+	if e.timeCache != nil {
+		buf.WriteString(e.timeCache(timeNow()))
 	} else {
-		buf.WriteString(e.timeCache(t))
+		buf.WriteTime(timeNow(), e.TimeFormat)
 	}
 	buf.WriteBytes(' ')
 }

--- a/encoder_json.go
+++ b/encoder_json.go
@@ -34,20 +34,20 @@ func NewJSONEncoder() *JSONEncoder {
 }
 
 // EncodeTime encodes the time of the log message.
-func (e *JSONEncoder) EncodeTime(buf *Buffer, t time.Time) {
+func (e *JSONEncoder) EncodeTime(buf *Buffer) {
 	if e.TimeFormat == "" {
 		return
 	}
-	if e.TimePrecision > 0 && e.timeCache == nil {
+	if e.timeCache == nil && e.TimePrecision > 0 {
 		e.timeCache = timeCache(e.TimeFormat, e.TimePrecision)
 	}
 	buf.WriteBytes('{')
-	if e.timeCache == nil {
-		buf.WriteBytes('"')
-		buf.WriteTime(t, e.TimeFormat)
-		buf.WriteBytes('"')
+	if e.timeCache != nil {
+		e.writeSafeField(buf, e.KeyTime, e.timeCache(timeNow()))
 	} else {
-		e.writeSafeField(buf, e.KeyTime, e.timeCache(t))
+		buf.WriteBytes('"')
+		buf.WriteTime(timeNow(), e.TimeFormat)
+		buf.WriteBytes('"')
 	}
 	buf.WriteBytes(',')
 }

--- a/encoder_json_test.go
+++ b/encoder_json_test.go
@@ -45,7 +45,7 @@ func TestJSONEncoderNoFieldsNoTime(t *testing.T) {
 	cfg.Level = LevelDebug
 
 	enc := NewJSONEncoder()
-	enc.Time = false
+	enc.TimeFormat = ""
 	cfg.Encoder = enc
 
 	logger := New(cfg)

--- a/encoder_json_test.go
+++ b/encoder_json_test.go
@@ -12,7 +12,7 @@ func TestJSONEncoder(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Output = &buf
 	cfg.Level = LevelDebug
-	cfg.Encoder = NewJSONEncoder(cfg)
+	cfg.Encoder = NewJSONEncoder()
 
 	logger := New(cfg)
 	ctx := context.Background()
@@ -29,7 +29,7 @@ func TestJSONEncoderNoFields(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Output = &buf
 	cfg.Level = LevelDebug
-	cfg.Encoder = NewJSONEncoder(cfg)
+	cfg.Encoder = NewJSONEncoder()
 
 	logger := New(cfg)
 	ctx := context.Background()
@@ -43,8 +43,10 @@ func TestJSONEncoderNoFieldsNoTime(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Output = &buf
 	cfg.Level = LevelDebug
-	cfg.Time = false
-	cfg.Encoder = NewJSONEncoder(cfg)
+
+	enc := NewJSONEncoder()
+	enc.Time = false
+	cfg.Encoder = enc
 
 	logger := New(cfg)
 	ctx := context.Background()
@@ -61,6 +63,6 @@ func validateAndPrintJSON(t *testing.T, buf bytes.Buffer) {
 
 	var data map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &data); err != nil {
-		t.Errorf("Failed to unmarshal JSON: %v", err)
+		t.Errorf("Failed to unmarshal JSON: %v\nJSON: %s", err, buf.String())
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -29,12 +29,7 @@ type Config struct {
 	Level           Level
 	Output          io.Writer
 	Encoder         Encoder
-	Time            bool
-	TimeFormat      string
 	TimePrecision   time.Duration
-	Color           bool
-	MinMessageWidth int
-	SortFields      bool
 	StackTraceLevel Level
 	StackTraceSkip  int
 }
@@ -81,15 +76,11 @@ func New(cfg Config) *Logger {
 		// Assume empty time format is the default one, not disabled
 		cfg.TimeFormat = defaultTimeFormat
 	}
-	if cfg.MinMessageWidth < 0 {
-		// Consider negative message width as no padding
-		cfg.MinMessageWidth = 0
-	}
 	if cfg.StackTraceLevel < LevelTrace || cfg.StackTraceLevel > LevelFatal {
 		cfg.StackTraceLevel = LevelError
 	}
 	if cfg.Encoder == nil {
-		cfg.Encoder = NewConsoleEncoder(cfg)
+		cfg.Encoder = NewConsoleEncoder()
 	}
 
 	l := &Logger{cfg: cfg, enc: cfg.Encoder}
@@ -101,20 +92,14 @@ func New(cfg Config) *Logger {
 
 // DefaultConfig returns a default configuration for the logger.
 func DefaultConfig() Config {
-	cfg := Config{
+	return Config{
 		Level:           LevelInfo,
 		Output:          os.Stderr,
-		Time:            true,
-		TimeFormat:      defaultTimeFormat,
 		TimePrecision:   0, // Disable time cache
-		Color:           true,
-		MinMessageWidth: defaultMessageWidth,
-		SortFields:      true,
 		StackTraceLevel: LevelError,
 		StackTraceSkip:  4,
+		Encoder:         NewConsoleEncoder(),
 	}
-	cfg.Encoder = NewConsoleEncoder(cfg)
-	return cfg
 }
 
 // Trace is used to log a message at the Trace level.

--- a/logger.go
+++ b/logger.go
@@ -151,7 +151,7 @@ func (l *Logger) print(lev Level, msg string, fields *[]Field) {
 	buf := getBuffer()
 	defer putBuffer(buf)
 
-	l.enc.EncodeTime(buf, timeNow())
+	l.enc.EncodeTime(buf)
 	l.enc.EncodeLevel(buf, lev)
 	l.enc.EncodeMessage(buf, msg)
 	l.enc.EncodeFields(buf, lev, fields)

--- a/logger.go
+++ b/logger.go
@@ -18,10 +18,9 @@ import (
 
 // Logger is a the main structure used to log messages.
 type Logger struct {
-	cfg       Config
-	enc       Encoder
-	timeCache func(time.Time) string
-	lock      sync.Mutex
+	cfg  Config
+	enc  Encoder
+	lock sync.Mutex
 }
 
 // Config is the configuration structure for the logger.
@@ -29,7 +28,6 @@ type Config struct {
 	Level           Level
 	Output          io.Writer
 	Encoder         Encoder
-	TimePrecision   time.Duration
 	StackTraceLevel Level
 	StackTraceSkip  int
 }
@@ -49,8 +47,9 @@ const (
 )
 
 var (
-	defaultMessageWidth = 40 // characters
-	defaultTimeFormat   = "2006-01-02 15:04:05.000"
+	defaultMessageWidth  = 40 // characters
+	defaultTimeFormat    = "2006-01-02 15:04:05.000"
+	defaultTimePrecision = 1 * time.Millisecond
 
 	// DurationFieldPrecision controls how duration values are truncated when
 	// logged.
@@ -72,10 +71,6 @@ func New(cfg Config) *Logger {
 	if cfg.Output == nil {
 		cfg.Output = os.Stderr
 	}
-	if cfg.TimeFormat == "" {
-		// Assume empty time format is the default one, not disabled
-		cfg.TimeFormat = defaultTimeFormat
-	}
 	if cfg.StackTraceLevel < LevelTrace || cfg.StackTraceLevel > LevelFatal {
 		cfg.StackTraceLevel = LevelError
 	}
@@ -83,11 +78,10 @@ func New(cfg Config) *Logger {
 		cfg.Encoder = NewConsoleEncoder()
 	}
 
-	l := &Logger{cfg: cfg, enc: cfg.Encoder}
-	if cfg.TimePrecision > 0 {
-		l.timeCache = timeCache(l.cfg.TimeFormat, l.cfg.TimePrecision)
+	return &Logger{
+		cfg: cfg,
+		enc: cfg.Encoder,
 	}
-	return l
 }
 
 // DefaultConfig returns a default configuration for the logger.
@@ -95,7 +89,6 @@ func DefaultConfig() Config {
 	return Config{
 		Level:           LevelInfo,
 		Output:          os.Stderr,
-		TimePrecision:   0, // Disable time cache
 		StackTraceLevel: LevelError,
 		StackTraceSkip:  4,
 		Encoder:         NewConsoleEncoder(),
@@ -158,9 +151,7 @@ func (l *Logger) print(lev Level, msg string, fields *[]Field) {
 	buf := getBuffer()
 	defer putBuffer(buf)
 
-	if l.cfg.Time {
-		l.enc.EncodeTime(buf, l.timeString())
-	}
+	l.enc.EncodeTime(buf, timeNow())
 	l.enc.EncodeLevel(buf, lev)
 	l.enc.EncodeMessage(buf, msg)
 	l.enc.EncodeFields(buf, lev, fields)
@@ -179,13 +170,6 @@ func (l *Logger) print(lev Level, msg string, fields *[]Field) {
 //
 // Helpers
 //
-
-func (l *Logger) timeString() string {
-	if l.timeCache != nil {
-		return l.timeCache(timeNow())
-	}
-	return timeNow().Format(l.cfg.TimeFormat)
-}
 
 // levelName returns level label that is consistently 4 characters long.
 func (lev Level) String() string {


### PR DESCRIPTION
Since JSON logger was introduced configuration no longer applies to both loggers equally with some options being unique to one or another logger. This change moves encoder-specific options to encoders themselves. 