### PR TITLE
Start/End encoder methods

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -2,6 +2,8 @@ package blip
 
 // Encoder is an interface for encoding log messages.
 type Encoder interface {
+	// Start writes the beginning of the log message.
+	Start(buf *Buffer)
 	// EncodeTime encodes the time of the log message.
 	EncodeTime(buf *Buffer)
 	// EncodeLevel encodes the log level of the message.
@@ -12,4 +14,6 @@ type Encoder interface {
 	EncodeFields(buf *Buffer, lev Level, fields *[]Field)
 	// EncodeStackTrace encodes the stack trace of the log message.
 	EncodeStackTrace(buf *Buffer, skip int)
+	// End writes the end of the log message.
+	End(buf *Buffer)
 }

--- a/encoder_console.go
+++ b/encoder_console.go
@@ -47,6 +47,9 @@ func NewConsoleEncoder() *ConsoleEncoder {
 	}
 }
 
+// Start writes the beginning of the log message.
+func (e *ConsoleEncoder) Start(_ *Buffer) {}
+
 // EncodeTime encodes the time of the log message.
 func (e *ConsoleEncoder) EncodeTime(buf *Buffer) {
 	if e.TimeFormat == "" {
@@ -97,7 +100,6 @@ func (e *ConsoleEncoder) EncodeMessage(buf *Buffer, msg string) {
 
 // EncodeFields encodes the fields of the log message.
 func (e *ConsoleEncoder) EncodeFields(buf *Buffer, lev Level, fields *[]Field) {
-	defer buf.WriteBytes('\n')
 	if fields == nil || len(*fields) == 0 {
 		return
 	}
@@ -119,9 +121,12 @@ func (e *ConsoleEncoder) EncodeFields(buf *Buffer, lev Level, fields *[]Field) {
 
 // EncodeStackTrace encodes the stack trace of the log message.
 func (e *ConsoleEncoder) EncodeStackTrace(buf *Buffer, skip int) {
-	// Print stack trace but skip the first 4 frames which are part of the
-	// logger itself.
+	buf.WriteBytes('\n')
 	buf.WriteString(stackTrace(skip))
+}
+
+// End writes the end of the log message.
+func (e *ConsoleEncoder) End(buf *Buffer) {
 	buf.WriteBytes('\n')
 }
 

--- a/logger.go
+++ b/logger.go
@@ -151,6 +151,7 @@ func (l *Logger) print(lev Level, msg string, fields *[]Field) {
 	buf := getBuffer()
 	defer putBuffer(buf)
 
+	l.enc.Start(buf)
 	l.enc.EncodeTime(buf)
 	l.enc.EncodeLevel(buf, lev)
 	l.enc.EncodeMessage(buf, msg)
@@ -161,6 +162,7 @@ func (l *Logger) print(lev Level, msg string, fields *[]Field) {
 	if lev >= l.cfg.StackTraceLevel {
 		l.enc.EncodeStackTrace(buf, l.cfg.StackTraceSkip)
 	}
+	l.enc.End(buf)
 
 	l.lock.Lock()
 	_, _ = l.cfg.Output.Write(buf.b)


### PR DESCRIPTION
Allows for easier separation of concerns between console and JSON encoders. 