### PR TITLE
Rename Cause helper to Err

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ log.Info("Callback received", log.F{
 
 Blip does not provide Printf-like methods, instead it encourages the use of
 fields. Fields are defined as a map, making it look nicely indented with `gofmt`.
-There is also a standardized helper for the error type: `log.Cause(err)`.
+There is also a standardized helper for the error type: `log.Err(err)`.
 
 ```go
-log.Error("Failed to process task", log.Cause(err), log.F{
+log.Error("Failed to process task", log.Err(err), log.F{
 	"task_id": 123456,
 })
 ```
@@ -41,7 +41,7 @@ ctx = log.WithContext(ctx, log.F{
 })
 
 if err := runTask(ctx, task); err != nil {
-	log.Error(ctx, "Task failed", log.Cause(err))
+	log.Error(ctx, "Task failed", log.Err(err))
 }
 ```
 

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -64,10 +64,10 @@ func main() {
 	log.Warn(blip.WithContext(ctx, log.F{"foo": "bar"}), "Duplicate task is exactly 39 characters", log.F{
 		"task_id": 123456,
 	})
-	log.Error(ctx, "Failed to process task", log.Cause(err), log.F{
+	log.Error(ctx, "Failed to process task", log.Err(err), log.F{
 		"task_id": 123456,
 	})
-	log.Panic(ctx, "Failed to start service", log.Cause(err), log.F{
+	log.Panic(ctx, "Failed to start service", log.Err(err), log.F{
 		"service": "api",
 	})
 }

--- a/ctx/log/log.go
+++ b/ctx/log/log.go
@@ -54,8 +54,8 @@ func Fatal(ctx context.Context, msg string, fields ...F) {
 	logger.Fatal(ctx, msg, fields...)
 }
 
-// Cause returns a field set that wraps the given error in a standardized way.
-func Cause(err error) F {
+// Err returns a field set that wraps the given error in a standardized way.
+func Err(err error) F {
 	return F{"error": err.Error()}
 }
 

--- a/noctx/log/log.go
+++ b/noctx/log/log.go
@@ -54,8 +54,8 @@ func Fatal(msg string, fields ...F) {
 	logger.Fatal(context.Background(), msg, fields...)
 }
 
-// Cause returns a field set that wraps the given error in a standardized way.
-func Cause(err error) F {
+// Err returns a field set that wraps the given error in a standardized way.
+func Err(err error) F {
 	return F{"error": err.Error()}
 }
 


### PR DESCRIPTION
Still undecided, considering renaming `log.Cause` to `log.Err`.

Upside: the logged error doesn't always represent the cause of an issue, so `Err` may be clearer.

Downside: there's already a `log.Error` function that must stay as it is, adding `log.Err` alongside it could be confusing.