### PR TITLE
Level formatters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
-.PHONY: lint test bench fuzz pprof demo demo-console demo-json
+.PHONY: all lint test bench fuzz pprof demo demo-console demo-json
 
-lint:
-	golangci-lint run
+all: test lint
 
 test:
 	go test -v -run=Test
+
+lint:
+	golangci-lint run
 
 bench:
 	go test -v -bench=. -benchmem -run=Benchmark

--- a/encoder_console.go
+++ b/encoder_console.go
@@ -10,7 +10,6 @@ import (
 type ConsoleEncoder struct {
 	TimeFormat      string
 	TimePrecision   time.Duration
-	LevelStringer   LevelStringer
 	MinMessageWidth int
 	SortFields      bool
 	Color           bool
@@ -42,7 +41,6 @@ func NewConsoleEncoder() *ConsoleEncoder {
 	return &ConsoleEncoder{
 		TimeFormat:      defaultTimeFormat,
 		TimePrecision:   defaultTimePrecision,
-		LevelStringer:   LevelShortUppercase,
 		MinMessageWidth: defaultMessageWidth,
 		SortFields:      true,
 		Color:           true,
@@ -70,10 +68,7 @@ func (e *ConsoleEncoder) EncodeTime(buf *Buffer) {
 
 // EncodeLevel encodes the log level of the message.
 func (e *ConsoleEncoder) EncodeLevel(buf *Buffer, lev Level) {
-	if e.LevelStringer == nil {
-		e.LevelStringer = LevelShortUppercase
-	}
-	e.writeColorized(buf, lev, e.LevelStringer(lev))
+	e.writeColorized(buf, lev, e.levelString(lev))
 	buf.WriteBytes(' ')
 }
 
@@ -202,4 +197,25 @@ func (e *ConsoleEncoder) writeColorized(buf *Buffer, lev Level, str string) {
 	}
 	buf.WriteString(str)
 	buf.WriteString(fontReset)
+}
+
+func (e *ConsoleEncoder) levelString(lev Level) string {
+	switch lev {
+	case LevelTrace:
+		return "TRAC"
+	case LevelDebug:
+		return "DEBU"
+	case LevelInfo:
+		return "INFO"
+	case LevelWarn:
+		return "WARN"
+	case LevelError:
+		return "ERRO"
+	case LevelPanic:
+		return "PANI"
+	case LevelFatal:
+		return "FATA"
+	default:
+		panic("unreachable")
+	}
 }

--- a/encoder_json.go
+++ b/encoder_json.go
@@ -10,7 +10,6 @@ import (
 type JSONEncoder struct {
 	TimeFormat     string
 	TimePrecision  time.Duration
-	LevelStringer  LevelStringer
 	Base64Encoding *base64.Encoding
 	KeyTime        string
 	KeyLevel       string
@@ -28,7 +27,6 @@ func NewJSONEncoder() *JSONEncoder {
 	return &JSONEncoder{
 		TimeFormat:     defaultTimeFormat,
 		TimePrecision:  defaultTimePrecision,
-		LevelStringer:  LevelFullLowercase,
 		Base64Encoding: base64.StdEncoding,
 		KeyTime:        "time",
 		KeyLevel:       "level",
@@ -64,13 +62,10 @@ func (e *JSONEncoder) EncodeTime(buf *Buffer) {
 
 // EncodeLevel encodes the log level of the message.
 func (e *JSONEncoder) EncodeLevel(buf *Buffer, lev Level) {
-	if e.LevelStringer == nil {
-		e.LevelStringer = LevelFullLowercase
-	}
 	if e.TimeFormat != "" {
 		buf.WriteBytes(',')
 	}
-	e.writeSafeField(buf, e.KeyLevel, e.LevelStringer(lev))
+	e.writeSafeField(buf, e.KeyLevel, e.levelString(lev))
 }
 
 // EncodeMessage encodes the log message.
@@ -163,5 +158,26 @@ func (e *JSONEncoder) writeAny(buf *Buffer, val any) {
 	default:
 		//nolint:errchkjson
 		_ = json.NewEncoder(buf).Encode(v)
+	}
+}
+
+func (e *JSONEncoder) levelString(lev Level) string {
+	switch lev {
+	case LevelTrace:
+		return "trace"
+	case LevelDebug:
+		return "debug"
+	case LevelInfo:
+		return "info"
+	case LevelWarn:
+		return "warn"
+	case LevelError:
+		return "error"
+	case LevelPanic:
+		return "panic"
+	case LevelFatal:
+		return "fatal"
+	default:
+		panic("unreachable")
 	}
 }

--- a/encoder_json.go
+++ b/encoder_json.go
@@ -48,9 +48,6 @@ func (e *JSONEncoder) EncodeTime(buf *Buffer) {
 		return
 	}
 
-	buf.WriteBytes('"')
-	buf.WriteString(e.KeyTime)
-	buf.WriteBytes('"', ':')
 	if e.TimePrecision > 0 {
 		if e.timeCache == nil {
 			e.timeCache = timeCache(e.TimeFormat, e.TimePrecision)
@@ -58,6 +55,8 @@ func (e *JSONEncoder) EncodeTime(buf *Buffer) {
 		e.writeSafeField(buf, e.KeyTime, e.timeCache(timeNow()))
 	} else {
 		buf.WriteBytes('"')
+		buf.WriteString(e.KeyTime)
+		buf.WriteBytes('"', ':', '"')
 		buf.WriteTime(timeNow(), e.TimeFormat)
 		buf.WriteBytes('"')
 	}

--- a/logger.go
+++ b/logger.go
@@ -35,9 +35,6 @@ type Config struct {
 // Level is the log level type.
 type Level int
 
-// LevelStringer is a function type that converts a log level to a string.
-type LevelStringer func(Level) string
-
 // Supported log levels.
 const (
 	LevelTrace Level = iota + 1

--- a/logger.go
+++ b/logger.go
@@ -35,6 +35,9 @@ type Config struct {
 // Level is the log level type.
 type Level int
 
+// LevelStringer is a function type that converts a log level to a string.
+type LevelStringer func(Level) string
+
 // Supported log levels.
 const (
 	LevelTrace Level = iota + 1
@@ -173,8 +176,9 @@ func (l *Logger) print(lev Level, msg string, fields *[]Field) {
 // Helpers
 //
 
-// levelName returns level label that is consistently 4 characters long.
-func (lev Level) String() string {
+// LevelShortUppercase returns level label that is first 4 characters in
+// uppercase.
+func LevelShortUppercase(lev Level) string {
 	switch lev {
 	case LevelTrace:
 		return "TRAC"
@@ -190,6 +194,28 @@ func (lev Level) String() string {
 		return "PANI"
 	case LevelFatal:
 		return "FATA"
+	default:
+		panic("unreachable")
+	}
+}
+
+// LevelFullLowercase returns level label that is all lowercase.
+func LevelFullLowercase(lev Level) string {
+	switch lev {
+	case LevelTrace:
+		return "trace"
+	case LevelDebug:
+		return "debug"
+	case LevelInfo:
+		return "info"
+	case LevelWarn:
+		return "warn"
+	case LevelError:
+		return "error"
+	case LevelPanic:
+		return "panic"
+	case LevelFatal:
+		return "fatal"
 	default:
 		panic("unreachable")
 	}

--- a/logger.go
+++ b/logger.go
@@ -176,51 +176,6 @@ func (l *Logger) print(lev Level, msg string, fields *[]Field) {
 // Helpers
 //
 
-// LevelShortUppercase returns level label that is first 4 characters in
-// uppercase.
-func LevelShortUppercase(lev Level) string {
-	switch lev {
-	case LevelTrace:
-		return "TRAC"
-	case LevelDebug:
-		return "DEBU"
-	case LevelInfo:
-		return "INFO"
-	case LevelWarn:
-		return "WARN"
-	case LevelError:
-		return "ERRO"
-	case LevelPanic:
-		return "PANI"
-	case LevelFatal:
-		return "FATA"
-	default:
-		panic("unreachable")
-	}
-}
-
-// LevelFullLowercase returns level label that is all lowercase.
-func LevelFullLowercase(lev Level) string {
-	switch lev {
-	case LevelTrace:
-		return "trace"
-	case LevelDebug:
-		return "debug"
-	case LevelInfo:
-		return "info"
-	case LevelWarn:
-		return "warn"
-	case LevelError:
-		return "error"
-	case LevelPanic:
-		return "panic"
-	case LevelFatal:
-		return "fatal"
-	default:
-		panic("unreachable")
-	}
-}
-
 func stackTrace(skip int) string {
 	// Get up to 100 stack frames
 	pc := make([]uintptr, 100)


### PR DESCRIPTION
- Consoler encoder prints levels in short uppercase format: `INFO`, `ERRO`
- JSON encoder does it in full lowercase format: `info`, `error`
- Fixed time key in JSON encoder