### PR TITLE
Rename context functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Such fields will be logged with every message.
 
 ```go
 ctx := context.Background()
-ctx = log.WithContext(ctx, log.F{
+ctx = log.ContextWithFields(ctx, log.F{
 	"task_id": task.ID,
 })
 

--- a/blip_test.go
+++ b/blip_test.go
@@ -202,8 +202,8 @@ func BenchmarkPrettySortedContext(b *testing.B) {
 		StackTraceLevel: blip.LevelError,
 	})
 	ctx := context.Background()
-	ctx = blip.WithContext(ctx, log.F{"foo": "bar"})
-	ctx = blip.WithContext(ctx, log.F{"one": "two"})
+	ctx = blip.ContextWithFields(ctx, log.F{"foo": "bar"})
+	ctx = blip.ContextWithFields(ctx, log.F{"one": "two"})
 
 	b.ResetTimer()
 	for range b.N {

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -61,7 +61,7 @@ func main() {
 	log.Warn(ctx, "Duplicate task but exactly 40 characters", log.F{
 		"task_id": 123456,
 	})
-	log.Warn(blip.WithContext(ctx, log.F{"foo": "bar"}), "Duplicate task is exactly 39 characters", log.F{
+	log.Warn(blip.ContextWithFields(ctx, log.F{"foo": "bar"}), "Duplicate task is exactly 39 characters", log.F{
 		"task_id": 123456,
 	})
 	log.Error(ctx, "Failed to process task", log.Cause(err), log.F{

--- a/context.go
+++ b/context.go
@@ -7,10 +7,10 @@ import (
 
 type contextKey struct{}
 
-// WithContext adds fields to the context. If the context already has fields,
-// it merges the new fields with the existing ones.
-func WithContext(ctx context.Context, fields F) context.Context {
-	existing := FromContext(ctx)
+// ContextWithFields adds fields to the context. If the context already has
+// fields, it merges the new fields with the existing ones.
+func ContextWithFields(ctx context.Context, fields F) context.Context {
+	existing := FieldsFromContext(ctx)
 	if existing == nil {
 		existing = fields
 	} else {
@@ -19,9 +19,9 @@ func WithContext(ctx context.Context, fields F) context.Context {
 	return context.WithValue(ctx, contextKey{}, existing)
 }
 
-// FromContext retrieves fields from the context. If no fields are found,
+// FieldsFromContext retrieves fields from the context. If no fields are found,
 // it returns nil.
-func FromContext(ctx context.Context) F {
+func FieldsFromContext(ctx context.Context) F {
 	if v, ok := ctx.Value(contextKey{}).(F); ok {
 		return v
 	}

--- a/ctx/log/log.go
+++ b/ctx/log/log.go
@@ -59,12 +59,12 @@ func Cause(err error) F {
 	return F{"error": err.Error()}
 }
 
-// WithContext adds logging fields to the context.
-func WithContext(ctx context.Context, fields F) context.Context {
-	return blip.WithContext(ctx, fields)
+// ContextWithFields adds logging fields to the context.
+func ContextWithFields(ctx context.Context, fields F) context.Context {
+	return blip.ContextWithFields(ctx, fields)
 }
 
-// FromContext retrieves logging fields from the context.
-func FromContext(ctx context.Context) F {
-	return blip.FromContext(ctx)
+// FieldsFromContext retrieves logging fields from the context.
+func FieldsFromContext(ctx context.Context) F {
+	return blip.FieldsFromContext(ctx)
 }

--- a/fields.go
+++ b/fields.go
@@ -27,7 +27,7 @@ func makeFields(ctx context.Context, ff []F) *[]Field {
 	}
 
 	fields := getFields()
-	for k, v := range FromContext(ctx) {
+	for k, v := range FieldsFromContext(ctx) {
 		addField(fields, k, v)
 	}
 	for _, f := range ff {

--- a/fields_test.go
+++ b/fields_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMakeFields(t *testing.T) {
 	ctx := context.Background()
-	ctx = WithContext(ctx, F{
+	ctx = ContextWithFields(ctx, F{
 		"a": 1,
 		"b": 2,
 	})

--- a/noctx/log/log.go
+++ b/noctx/log/log.go
@@ -59,12 +59,12 @@ func Cause(err error) F {
 	return F{"error": err.Error()}
 }
 
-// WithContext adds logging fields to the context.
-func WithContext(ctx context.Context, fields F) context.Context {
-	return blip.WithContext(ctx, fields)
+// ContextWithFields adds logging fields to the context.
+func ContextWithFields(ctx context.Context, fields F) context.Context {
+	return blip.ContextWithFields(ctx, fields)
 }
 
-// FromContext retrieves the field set from the context.
-func FromContext(ctx context.Context) F {
-	return blip.FromContext(ctx)
+// FieldsFromContext retrieves the field set from the context.
+func FieldsFromContext(ctx context.Context) F {
+	return blip.FieldsFromContext(ctx)
 }


### PR DESCRIPTION
- `WithContext` is renamed to `ContextWithFields`
- `FromContext` is renamed to `FieldsFromContext`

New function names indicate their behavior in a clear and unambiguous way.