### PR TITLE
Don't skip context fields

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -18,7 +18,8 @@ type F map[string]any
 // Explicitly logged fields take precedence over context fields. Last field set
 // wins if there are duplicates.
 func makeFields(ctx context.Context, ff []F) *[]Field {
-	var n int
+	cf := FieldsFromContext(ctx)
+	n := len(cf)
 	for _, f := range ff {
 		n += len(f)
 	}
@@ -27,7 +28,7 @@ func makeFields(ctx context.Context, ff []F) *[]Field {
 	}
 
 	fields := getFields()
-	for k, v := range FieldsFromContext(ctx) {
+	for k, v := range cf {
 		addField(fields, k, v)
 	}
 	for _, f := range ff {

--- a/fields_test.go
+++ b/fields_test.go
@@ -29,6 +29,33 @@ func TestMakeFields(t *testing.T) {
 	}
 }
 
+func TestMakeFieldsEmpty(t *testing.T) {
+	ctx := context.Background()
+	fields := makeFields(ctx, []F{})
+	if fields != nil {
+		t.Errorf("expected nil, got %v", fields)
+	}
+}
+
+func TestMakeFieldsOnlyContext(t *testing.T) {
+	ctx := context.Background()
+	ctx = ContextWithFields(ctx, F{
+		"a": 1,
+	})
+	fields := makeFields(ctx, nil)
+	if fields == nil {
+		t.Fatal("expected non-nil fields")
+	}
+	defer putFields(fields)
+
+	exp := []Field{
+		{"a", 1},
+	}
+	if !slices.Equal(exp, *fields) {
+		t.Errorf("expected %v, got %v", exp, *fields)
+	}
+}
+
 func TestSortFields(t *testing.T) {
 	fields := []Field{
 		{"b", 2},


### PR DESCRIPTION
When context has fields but a call to logger doesn't, context fields are not displayed.